### PR TITLE
changed image path

### DIFF
--- a/src/components/BackgroundSection.js
+++ b/src/components/BackgroundSection.js
@@ -22,7 +22,7 @@ const BackgroundSection = ({ className, children }) => {
   const { desktop } = useStaticQuery(
     graphql`
       query {
-        desktop: file(relativePath: { eq: "seamless-bg-desktop.jpg" }) {
+        desktop: file(relativePath: { eq: "images/seamless-bg-desktop.jpg" }) {
           childImageSharp {
             fluid(quality: 90, maxWidth: 4160) {
               ...GatsbyImageSharpFluid_withWebp_tracedSVG


### PR DESCRIPTION
I changed the image path to "images/ImageName.fileformat" because without images/ part, the snippet did not work in my project but it did with it, and also I confirmed that the code still worked in your example project so I thought it'd save time for developers in the future if they didn't have to bump into the same issue.